### PR TITLE
More comfortable desktop chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # bspwm-ruler
 Configuration utility for bspwm
 
-Requires bash, xprop (for choosing windows with mouse) and fzf (for menus).
+Requires:
+- bash
+- xprop (for choosing windows with mouse)
+- jq (for choosing a desktop from a list with monitor name and desktop name included)
+- fzf (for menus).

--- a/bspwm-ruler
+++ b/bspwm-ruler
@@ -109,7 +109,7 @@ main()
     echo -e " ┌─────────────────────────────────────────────────────────────┐"
     echo -e " │    1   Add a rule                   2   Remove a rule       │"
     echo -e " │    3   Configure settings           4   Disable a rule      │"
-    echo -e " │    5   Edit keydindings             6   Edit .profile       │"
+    echo -e " │    5   Edit keybindings             6   Edit .profile       │"
     echo -e " │    7   Edit autostart               8   Edit bspwmrc        │"
     echo -e " └─────────────────────────────────────────────────────────────┘"
     echo -e "          Select an item       -       0   Exit "

--- a/bspwm-ruler
+++ b/bspwm-ruler
@@ -26,13 +26,15 @@ rule_ops()
 		window_flags=$(echo -e "sticky=on\nprivate=on\nlocked=on\nurgent=on\n " | fzf-tmux -e -m --reverse --prompt='Choose window flags (tab to select multiple, choose empty if you want none) >')
 		[ -n "$window_flags" ] && echo -e "$window_flags" >> /tmp/rule_ops
 
-		window_desktop=$(echo -e "$(bspc query -D)\nAny" | fzf-tmux -e --reverse --prompt='Desktop= >')
+		desktops=$(bspc wm --dump-state | jq -r '.monitors[] | { desktopName: .name} + .desktops[] |  [.desktopName,.name,(.id|tostring)] | @tsv')
+
+		window_desktop=$(echo -e "${desktops}\nAny" | fzf-tmux -e --reverse --prompt='Desktop= >')
 		echo "$window_desktop" | {
 		read desk
 		if [ "$desk" = 'Any' ] ; then
 			echo ""
 		else
-			[ -n "$desk" ] && echo -e "desktop=$desk" >> /tmp/rule_ops
+			[ -n "$desk" ] && echo -e "desktop=$( cut -d$'\t' -f3 <<< "$desk")" >> /tmp/rule_ops
 		fi
 	}
 	# choose if window should be followed if it spawns on another desktop
@@ -107,7 +109,7 @@ main()
     echo -e " ┌─────────────────────────────────────────────────────────────┐"
     echo -e " │    1   Add a rule                   2   Remove a rule       │"
     echo -e " │    3   Configure settings           4   Disable a rule      │"
-    echo -e " │    5   Edit keydindings             6   Edit .profile       │"    
+    echo -e " │    5   Edit keydindings             6   Edit .profile       │"
     echo -e " │    7   Edit autostart               8   Edit bspwmrc        │"
     echo -e " └─────────────────────────────────────────────────────────────┘"
     echo -e "          Select an item       -       0   Exit "


### PR DESCRIPTION
Hey,
I have implemented a much better (in my opinion) way of displaying the desktop chooser.
It needs additional dependency - `jq` - but in return you get a nice list with 
`monitor name | desktop name | desktop id`

This is how it looks:
![image](https://user-images.githubusercontent.com/14099001/107502956-a8bc1980-6b99-11eb-9d11-820244310754.png)
